### PR TITLE
ENH: Changed test macros to require lvalues

### DIFF
--- a/src/Plugins/ITKImageProcessing/test/ITKImageWriterTest.cpp
+++ b/src/Plugins/ITKImageProcessing/test/ITKImageWriterTest.cpp
@@ -385,8 +385,10 @@ TEST_CASE("ITKImageProcessing::ITKImageWriterFilter: RGBA Image Output", "[ITKIm
   args.insertOrAssign(ITKImageWriterFilter::k_TotalIndexDigits_Key, std::make_any<Int32Parameter::ValueType>(3));
   args.insertOrAssign(ITKImageWriterFilter::k_LeadingDigitCharacter_Key, std::make_any<StringParameter::ValueType>("0"));
 
-  SIMPLNX_RESULT_REQUIRE_VALID(filter.preflight(dataStructure, args).outputActions);
-  SIMPLNX_RESULT_REQUIRE_VALID(filter.execute(dataStructure, args).result);
+  auto preflightResult = filter.preflight(dataStructure, args).outputActions;
+  SIMPLNX_RESULT_REQUIRE_VALID(preflightResult);
+  auto executeResult = filter.execute(dataStructure, args).result;
+  SIMPLNX_RESULT_REQUIRE_VALID(executeResult);
 
   using ImageType = itk::Image<itk::RGBAPixel<uint8>, 2>;
   auto reader = itk::ImageFileReader<ImageType>::New();

--- a/src/Plugins/SimplnxCore/test/KeepRemoveRankedFeaturesTest.cpp
+++ b/src/Plugins/SimplnxCore/test/KeepRemoveRankedFeaturesTest.cpp
@@ -497,9 +497,11 @@ TEST_CASE("SimplnxCore::KeepRemoveRankedFeaturesFilter: Invariants", "[SimplnxCo
     // Keeping 2 gives {1, 4}; keeping 3 gives {1, 4, 3}. Compare cell-wise: every cell surviving
     // under k=2 must also survive under k=3.
     DataStructure smallDs = BuildFiveFeatureData();
-    SIMPLNX_RESULT_REQUIRE_VALID(filter.execute(smallDs, MakeArgs(0ULL, 0ULL, 2ULL)).result);
+    auto smallDsResult = filter.execute(smallDs, MakeArgs(0ULL, 0ULL, 2ULL)).result;
+    SIMPLNX_RESULT_REQUIRE_VALID(smallDsResult);
     DataStructure largeDs = BuildFiveFeatureData();
-    SIMPLNX_RESULT_REQUIRE_VALID(filter.execute(largeDs, MakeArgs(0ULL, 0ULL, 3ULL)).result);
+    auto largeDsResult = filter.execute(largeDs, MakeArgs(0ULL, 0ULL, 3ULL)).result;
+    SIMPLNX_RESULT_REQUIRE_VALID(largeDsResult);
 
     const std::vector<int32> smallIds = ReadFeatureIds(smallDs);
     const std::vector<int32> largeIds = ReadFeatureIds(largeDs);

--- a/test/UnitTestCommon/include/simplnx/UnitTest/UnitTestCommon.hpp
+++ b/test/UnitTestCommon/include/simplnx/UnitTest/UnitTestCommon.hpp
@@ -42,12 +42,14 @@ using namespace nx::core;
 
 namespace nx::core
 {
-// Concept that checks if T is an instance of Result<T>
+template <class>
+inline constexpr bool IsResult_v = false;
+
 template <class T>
-concept IsResult = requires(T x) {
-  { Result{x} } -> std::same_as<T>;
-};
+inline constexpr bool IsResult_v<Result<T>> = true;
 } // namespace nx::core
+
+#define NX_IS_LVALUE_RESULT(value) (IsResult_v<std::remove_cvref_t<decltype(value)>> && std::is_lvalue_reference_v<decltype((value))>)
 
 #define SIMPLNX_RESULT_CATCH_PRINT(result)                                                                                                                                                             \
   for(const auto& warning : (result).warnings())                                                                                                                                                       \
@@ -65,17 +67,17 @@ concept IsResult = requires(T x) {
 #define SIMPLNX_RESULT_REQUIRE_VALID(result)                                                                                                                                                           \
   do                                                                                                                                                                                                   \
   {                                                                                                                                                                                                    \
-    const IsResult auto NX_TEST_RESULT = (result);                                                                                                                                                     \
-    SIMPLNX_RESULT_CATCH_PRINT(NX_TEST_RESULT);                                                                                                                                                        \
-    REQUIRE(NX_TEST_RESULT.valid());                                                                                                                                                                   \
+    static_assert(NX_IS_LVALUE_RESULT(result), "SIMPLNX_RESULT_REQUIRE_VALID requires an lvalue Result<T>");                                                                                           \
+    SIMPLNX_RESULT_CATCH_PRINT(result);                                                                                                                                                                \
+    REQUIRE((result).valid());                                                                                                                                                                         \
   } while(false);
 
 #define SIMPLNX_RESULT_REQUIRE_INVALID(result)                                                                                                                                                         \
   do                                                                                                                                                                                                   \
   {                                                                                                                                                                                                    \
-    const IsResult auto NX_TEST_RESULT = (result);                                                                                                                                                     \
-    SIMPLNX_RESULT_CATCH_PRINT(NX_TEST_RESULT);                                                                                                                                                        \
-    REQUIRE(NX_TEST_RESULT.invalid());                                                                                                                                                                 \
+    static_assert(NX_IS_LVALUE_RESULT(result), "SIMPLNX_RESULT_REQUIRE_INVALID requires an lvalue Result<T>");                                                                                         \
+    SIMPLNX_RESULT_CATCH_PRINT(result);                                                                                                                                                                \
+    REQUIRE((result).invalid());                                                                                                                                                                       \
   } while(false);
 
 namespace nx::core

--- a/test/UnitTestCommon/include/simplnx/UnitTest/UnitTestCommon.hpp
+++ b/test/UnitTestCommon/include/simplnx/UnitTest/UnitTestCommon.hpp
@@ -40,6 +40,15 @@
 namespace fs = std::filesystem;
 using namespace nx::core;
 
+namespace nx::core
+{
+// Concept that checks if T is an instance of Result<T>
+template <class T>
+concept IsResult = requires(T x) {
+  { Result{x} } -> std::same_as<T>;
+};
+} // namespace nx::core
+
 #define SIMPLNX_RESULT_CATCH_PRINT(result)                                                                                                                                                             \
   for(const auto& warning : (result).warnings())                                                                                                                                                       \
   {                                                                                                                                                                                                    \
@@ -54,12 +63,20 @@ using namespace nx::core;
   }
 
 #define SIMPLNX_RESULT_REQUIRE_VALID(result)                                                                                                                                                           \
-  SIMPLNX_RESULT_CATCH_PRINT(result);                                                                                                                                                                  \
-  REQUIRE((result).valid());
+  do                                                                                                                                                                                                   \
+  {                                                                                                                                                                                                    \
+    const IsResult auto NX_TEST_RESULT = (result);                                                                                                                                                     \
+    SIMPLNX_RESULT_CATCH_PRINT(NX_TEST_RESULT);                                                                                                                                                        \
+    REQUIRE(NX_TEST_RESULT.valid());                                                                                                                                                                   \
+  } while(false);
 
 #define SIMPLNX_RESULT_REQUIRE_INVALID(result)                                                                                                                                                         \
-  SIMPLNX_RESULT_CATCH_PRINT(result);                                                                                                                                                                  \
-  REQUIRE((result).invalid());
+  do                                                                                                                                                                                                   \
+  {                                                                                                                                                                                                    \
+    const IsResult auto NX_TEST_RESULT = (result);                                                                                                                                                     \
+    SIMPLNX_RESULT_CATCH_PRINT(NX_TEST_RESULT);                                                                                                                                                        \
+    REQUIRE(NX_TEST_RESULT.invalid());                                                                                                                                                                 \
+  } while(false);
 
 namespace nx::core
 {


### PR DESCRIPTION
Fixes #1704

`SIMPLNX_RESULT_REQUIRE_VALID` and `SIMPLNX_RESULT_REQUIRE_INVALID` now assign the input `Result<T>` to avoid macro duplication when the argument is an expression (may copy or move depending on input type).

For tests, I think the following typical form should still be preferred since it allows for easy access to the `Result` in the debugger. This PR mainly serves as a guard against unintended behavior. 
```cpp
  auto executeResult = filter.execute(dataStructure, args);
  SIMPLNX_RESULT_REQUIRE_VALID(executeResult.result);
```