### PR TITLE
CI: Updated actions to avoid deprecation issues

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -27,13 +27,9 @@ jobs:
       - name: Add C++ Problem Matcher
         uses: ammaraskar/gcc-problem-matcher@cb2e3f949c41b7818628f35f8484a9b0acf90cf9
       - name: Install mono
-        shell: bash
         run: |
-          sudo apt-get -y install ca-certificates gnupg
-          sudo gpg --homedir /tmp --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-          echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
-          sudo apt-get -y update
-          sudo apt-get -y install mono-complete
+          sudo apt-get update
+          sudo apt-get install mono-complete
       - name: Setup NuGet Credentials
         shell: bash
         run: |

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -26,9 +26,6 @@ jobs:
           pip install sphinx myst-parser sphinx-markdown-tables sphinx_rtd_theme numpy
       - name: Add C++ Problem Matcher
         uses: ammaraskar/gcc-problem-matcher@cb2e3f949c41b7818628f35f8484a9b0acf90cf9
-      - name: Install Dependencies
-        run: |
-          sudo apt-get -y install ninja-build
       - name: Install mono
         shell: bash
         run: |

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v7
         with:
           python-version: '3.10'
       - name: Install Python dependencies
@@ -25,7 +25,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install sphinx myst-parser sphinx-markdown-tables sphinx_rtd_theme numpy
       - name: Add C++ Problem Matcher
-        uses: ammaraskar/gcc-problem-matcher@0.2.0
+        uses: ammaraskar/gcc-problem-matcher@cb2e3f949c41b7818628f35f8484a9b0acf90cf9
       - name: Install Dependencies
         run: |
           sudo apt-get -y install ninja-build

--- a/.github/workflows/format_pr.yml
+++ b/.github/workflows/format_pr.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 2
       - name: Add Problem Matcher
-        uses: ammaraskar/gcc-problem-matcher@a141586609e2a558729b99a8c574c048f7f56204
+        uses: ammaraskar/gcc-problem-matcher@cb2e3f949c41b7818628f35f8484a9b0acf90cf9
       - name: Install clang-format-19
         run: |
           sudo apt-get update

--- a/.github/workflows/format_push.yml
+++ b/.github/workflows/format_push.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
       - name: Add Problem Matcher
-        uses: ammaraskar/gcc-problem-matcher@a141586609e2a558729b99a8c574c048f7f56204
+        uses: ammaraskar/gcc-problem-matcher@cb2e3f949c41b7818628f35f8484a9b0acf90cf9
       - name: Install clang-format-19
         run: |
           sudo apt-get update

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,11 +20,11 @@ jobs:
         os:
           - ubuntu-24.04
         cxx:
-          - g++-14
+          - g++-13
           - clang++-16
         include:
-          - cxx: g++-14
-            cc: gcc-14
+          - cxx: g++-13
+            cc: gcc-13
           - cxx: clang++-16
             cc: clang-16
     runs-on: ${{matrix.os}}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -30,11 +30,11 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v7
         with:
           python-version: '3.10'
       - name: Install Python dependencies
@@ -42,7 +42,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install sphinx myst-parser sphinx-markdown-tables sphinx_rtd_theme numpy
       - name: Add C++ Problem Matcher
-        uses: ammaraskar/gcc-problem-matcher@0.2.0
+        uses: ammaraskar/gcc-problem-matcher@cb2e3f949c41b7818628f35f8484a9b0acf90cf9
       - name: Install Dependencies - 2
         run: |
           sudo apt-get -y install ninja-build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -43,6 +43,10 @@ jobs:
           pip install sphinx myst-parser sphinx-markdown-tables sphinx_rtd_theme numpy
       - name: Add C++ Problem Matcher
         uses: ammaraskar/gcc-problem-matcher@cb2e3f949c41b7818628f35f8484a9b0acf90cf9
+      - name: Install mono
+        run: |
+          sudo apt-get update
+          sudo apt-get install mono-complete
       - name: Setup NuGet Credentials
         shell: bash
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -46,9 +46,6 @@ jobs:
       - name: Install Dependencies - 2
         run: |
           sudo apt-get -y install ninja-build
-      - name: Install Sphinx
-        run: |
-          sudo pip3 install sphinx myst-parser sphinx-markdown-tables sphinx_rtd_theme numpy
       - name: Setup NuGet Credentials
         shell: bash
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,15 +18,15 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-24.04
         cxx:
-          - g++-11
-          - clang++-14
+          - g++-12
+          - clang++-16
         include:
-          - cxx: g++-11
-            cc: gcc-11
-          - cxx: clang++-14
-            cc: clang-14
+          - cxx: g++-12
+            cc: gcc-12
+          - cxx: clang++-16
+            cc: clang-16
     runs-on: ${{matrix.os}}
     steps:
       - name: Checkout

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -43,9 +43,6 @@ jobs:
           pip install sphinx myst-parser sphinx-markdown-tables sphinx_rtd_theme numpy
       - name: Add C++ Problem Matcher
         uses: ammaraskar/gcc-problem-matcher@cb2e3f949c41b7818628f35f8484a9b0acf90cf9
-      - name: Install Dependencies
-        run: |
-          sudo apt-get -y install ninja-build
       - name: Setup NuGet Credentials
         shell: bash
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -43,7 +43,7 @@ jobs:
           pip install sphinx myst-parser sphinx-markdown-tables sphinx_rtd_theme numpy
       - name: Add C++ Problem Matcher
         uses: ammaraskar/gcc-problem-matcher@cb2e3f949c41b7818628f35f8484a9b0acf90cf9
-      - name: Install Dependencies - 2
+      - name: Install Dependencies
         run: |
           sudo apt-get -y install ninja-build
       - name: Setup NuGet Credentials

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,11 +20,11 @@ jobs:
         os:
           - ubuntu-24.04
         cxx:
-          - g++-13
+          - g++-14
           - clang++-16
         include:
-          - cxx: g++-13
-            cc: gcc-13
+          - cxx: g++-14
+            cc: gcc-14
           - cxx: clang++-16
             cc: clang-16
     runs-on: ${{matrix.os}}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,11 +20,11 @@ jobs:
         os:
           - ubuntu-24.04
         cxx:
-          - g++-12
+          - g++-13
           - clang++-16
         include:
-          - cxx: g++-12
-            cc: gcc-12
+          - cxx: g++-13
+            cc: gcc-13
           - cxx: clang++-16
             cc: clang-16
     runs-on: ${{matrix.os}}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -50,7 +50,7 @@ jobs:
         uses: ammaraskar/gcc-problem-matcher@cb2e3f949c41b7818628f35f8484a9b0acf90cf9
       - name: Install Dependencies
         run: |
-          brew install ninja mono
+          brew install mono
       - name: Install Sphinx
         run: |
           sudo pip3 install sphinx myst-parser sphinx-markdown-tables sphinx_rtd_theme numpy

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,11 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-14
           - macos-15
         include:
-          - os: macos-14
-            preset: ci-macos-arm64
           - os: macos-15
             preset: ci-macos-arm64
     runs-on: ${{matrix.os}}
@@ -31,13 +28,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: true
-      - name: Checkout vcpkg
-        run: |
-            git clone https://www.github.com/microsoft/vcpkg && cd vcpkg && ./bootstrap-vcpkg.sh
-            VCPKG_INSTALLATION_ROOT=${{github.workspace}}/vcpkg
-            echo "$VCPKG_INSTALLATION_ROOT" >> $GITHUB_PATH
-            echo "VCPKG_INSTALLATION_ROOT=$VCPKG_INSTALLATION_ROOT" >> "$GITHUB_ENV"
-        if: matrix.os == 'macos-14'
       - name: Set up Python
         uses: actions/setup-python@v7
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           submodules: true
       - name: Checkout vcpkg
@@ -39,7 +39,7 @@ jobs:
             echo "VCPKG_INSTALLATION_ROOT=$VCPKG_INSTALLATION_ROOT" >> "$GITHUB_ENV"
         if: matrix.os == 'macos-14'
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v7
         with:
           python-version: '3.10'
       - name: Install Python dependencies
@@ -47,7 +47,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install sphinx myst-parser sphinx-markdown-tables sphinx_rtd_theme numpy
       - name: Add C++ Problem Matcher
-        uses: ammaraskar/gcc-problem-matcher@0.2.0
+        uses: ammaraskar/gcc-problem-matcher@cb2e3f949c41b7818628f35f8484a9b0acf90cf9
       - name: Install Dependencies
         run: |
           brew install ninja mono

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,9 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-15
+          - macos-26
         include:
-          - os: macos-15
+          - os: macos-26
             preset: ci-macos-arm64
     runs-on: ${{matrix.os}}
     steps:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -51,9 +51,6 @@ jobs:
       - name: Install Dependencies
         run: |
           brew install mono
-      - name: Install Sphinx
-        run: |
-          sudo pip3 install sphinx myst-parser sphinx-markdown-tables sphinx_rtd_theme numpy
       - name: Setup NuGet Credentials
         shell: bash
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,11 +24,11 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           submodules: true
       - name: Add C++ Problem Matcher
-        uses: ammaraskar/msvc-problem-matcher@0.2.0
+        uses: ammaraskar/msvc-problem-matcher@541aa4360062d76d9620af6b8bd35cfa0c5ef19f
       - name: Setup Build Environment
         uses: ilammy/msvc-dev-cmd@v1.12.1
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,10 +29,6 @@ jobs:
           submodules: true
       - name: Add C++ Problem Matcher
         uses: ammaraskar/msvc-problem-matcher@541aa4360062d76d9620af6b8bd35cfa0c5ef19f
-      - name: Setup Build Environment
-        uses: ilammy/msvc-dev-cmd@v1.12.1
-        with:
-          vsversion: 2022
       - name: Setup NuGet Credentials
         shell: bash
         run: |

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/SharedFeatureFace.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/SharedFeatureFace.cpp
@@ -192,7 +192,18 @@ Result<> SharedFeatureFace::operator()()
   // Grain Boundary Attribute Matrix
   auto& faceFeatureAttrMat = m_DataStructure.getDataRefAs<AttributeMatrix>(m_InputValues->GrainBoundaryAttributeMatrixPath);
   ShapeType tDims = {static_cast<usize>(index)};
+  // This line has a Wstringop-overflow warning starting in gcc 12.4 in release configuration
+  // This is a false positive that eventually disappears in gcc 15
+  // Likely related to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94335
+  // Minimum reproducible example: https://godbolt.org/z/qTr8hPo1e
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 15 && (__GNUC__ > 12 || (__GNUC__ == 12 && __GNUC_MINOR__ >= 4))
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
   faceFeatureAttrMat.resizeTuples(tDims);
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 15 && (__GNUC__ > 12 || (__GNUC__ == 12 && __GNUC_MINOR__ >= 4))
+#pragma GCC diagnostic pop
+#endif
 
   auto& surfaceMeshFeatureFaceLabels = m_DataStructure.getDataAs<Int32Array>(m_InputValues->FeatureFaceLabelsArrayPath)->getDataStoreRef();
   auto& surfaceMeshFeatureFaceNumTriangles = m_DataStructure.getDataAs<Int32Array>(m_InputValues->FeatureFaceNumTrianglesArrayPath)->getDataStoreRef();

--- a/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteStlFile.cpp
+++ b/src/Plugins/SimplnxCore/src/SimplnxCore/Filters/Algorithms/WriteStlFile.cpp
@@ -82,7 +82,6 @@ Result<> SingleWriteOutStl(WriteStlFile* filter, const fs::path& path, const IGe
 
   if(filePtr == nullptr)
   {
-    fclose(filePtr);
     return {MakeWarningVoidResult(-27886, fmt::format("Error Opening STL File. Unable to create temp file at path '{}' for original file '{}'", path.string(), path.filename().string()))};
   }
 
@@ -252,7 +251,6 @@ public:
 
     if(filePtr == nullptr)
     {
-      fclose(filePtr);
       m_Filter->sendThreadSafeProgressMessage(
           {MakeWarningVoidResult(-27876, fmt::format("Error Opening STL File. Unable to create temp file at path '{}' for original file '{}'", activePath.string(), activePath.filename().string()))});
       return;


### PR DESCRIPTION
- Updated actions to versions that use Node 24 since Node 20 is being deprecated
  - actions/checkout@v7
  - actions/setup-python@v7
  - ammaraskar/gcc-problem-matcher@cb2e3f949c41b7818628f35f8484a9b0acf90cf9
  - ammaraskar/msvc-problem-matcher@541aa4360062d76d9620af6b8bd35cfa0c5ef19f
- Removed ilammy/msvc-dev-cmd since it is no longer required due only one Visual Studio instance being installed on the windows-2022 image. Additionally it has not been updated in several years and does not have a Node 24 version
- Removed extraneous install steps
- Switched to macos-26 since macos-14 is being deprecated
- Switched to ubuntu-24.04 since ubuntu 22.04 is being deprecated
  - Switched to gcc-13
    - Disabled Wstringop-overflow warning for 12.4 <= gcc < 15
    - Fixed fclose null warning
  - Switched to clang-16