### PR TITLE
CI: Change the clang-format workflows to be reusable

### DIFF
--- a/.github/workflows/format_pr.yml
+++ b/.github/workflows/format_pr.yml
@@ -26,7 +26,8 @@ jobs:
         with:
           path: ${{ env.REPO_PATH }}
           fetch-depth: 2
-      - uses: actions/checkout@v7
+      - name: Checkout workflow script
+        uses: actions/checkout@v7
         if: ${{ github.repository != job.workflow_repository }}
         with:
           repository: ${{ job.workflow_repository }}

--- a/.github/workflows/format_pr.yml
+++ b/.github/workflows/format_pr.yml
@@ -21,7 +21,7 @@ jobs:
           WORKFLOW_PATH: workflow/${{ job.workflow_repository }}
         run: |
           echo "WORKFLOW_PATH=$WORKFLOW_PATH" >> "$GITHUB_OUTPUT"
-          echo "CLANG_FORMAT_SCRIPT_DIR=${{ case(github.repository != job.workflow_repository, env.WORKFLOW_PATH, env.REPO_PATH) }}" >> $GITHUB_ENV
+          echo "CLANG_FORMAT_SCRIPT_DIR=$GITHUB_WORKSPACE/${{ case(github.repository != job.workflow_repository, env.WORKFLOW_PATH, env.REPO_PATH) }}" >> $GITHUB_ENV
       - uses: actions/checkout@v7
         with:
           path: ${{ env.REPO_PATH }}

--- a/.github/workflows/format_pr.yml
+++ b/.github/workflows/format_pr.yml
@@ -13,9 +13,15 @@ jobs:
 
     env:
       REPO_PATH: repo/${{ github.repository }}
-      WORKFLOW_PATH: workflow/${{ job.workflow_repository }}
 
     steps:
+      - name: Setup env vars
+        id: setup_env_vars
+        env:
+          WORKFLOW_PATH: workflow/${{ job.workflow_repository }}
+        run: |
+          echo "WORKFLOW_PATH=$WORKFLOW_PATH" >> "$GITHUB_OUTPUT"
+          echo "CLANG_FORMAT_SCRIPT_DIR=${{ case(github.repository != job.workflow_repository, env.WORKFLOW_PATH, env.REPO_PATH) }}" >> $GITHUB_ENV
       - uses: actions/checkout@v7
         with:
           path: ${{ env.REPO_PATH }}
@@ -25,7 +31,7 @@ jobs:
         with:
           repository: ${{ job.workflow_repository }}
           ref: ${{ job.workflow_sha }}
-          path: ${{ env.WORKFLOW_PATH }}
+          path: ${{ steps.setup_env_vars.outputs.WORKFLOW_PATH }}
           sparse-checkout: |
             scripts/clang_format.py
           sparse-checkout-cone-mode: false
@@ -39,15 +45,11 @@ jobs:
       - name: Check Formatting
         id: check_format
         continue-on-error: true
-        env:
-          CLANG_FORMAT_SCRIPT_DIR: ${{ case(github.repository != job.workflow_repository, env.WORKFLOW_PATH, env.REPO_PATH) }}
         working-directory: ${{ env.REPO_PATH }}
         run: |
           python3 "$CLANG_FORMAT_SCRIPT_DIR/scripts/clang_format.py" --format-version 19 --commits HEAD^ HEAD
       - name: Apply Formatting
         if: steps.check_format.outcome != 'success'
-        env:
-          CLANG_FORMAT_SCRIPT_DIR: ${{ case(github.repository != job.workflow_repository, env.WORKFLOW_PATH, env.REPO_PATH) }}
         working-directory: ${{ env.REPO_PATH }}
         run: |
           python3 "$CLANG_FORMAT_SCRIPT_DIR/scripts/clang_format.py" --format-version 19 --modify --commits HEAD^ HEAD

--- a/.github/workflows/format_pr.yml
+++ b/.github/workflows/format_pr.yml
@@ -5,15 +5,30 @@ on:
     branches:
       - develop
       - master
+  workflow_call:
 
 jobs:
   clang_format_pr:
     runs-on: ubuntu-24.04
 
+    env:
+      REPO_PATH: repo/${{ github.repository }}
+      WORKFLOW_PATH: workflow/${{ job.workflow_repository }}
+
     steps:
       - uses: actions/checkout@v7
         with:
+          path: ${{ env.REPO_PATH }}
           fetch-depth: 2
+      - uses: actions/checkout@v7
+        if: ${{ github.repository != job.workflow_repository }}
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          path: ${{ env.WORKFLOW_PATH }}
+          sparse-checkout: |
+            scripts/clang_format.py
+          sparse-checkout-cone-mode: false
       - name: Add Problem Matcher
         uses: ammaraskar/gcc-problem-matcher@cb2e3f949c41b7818628f35f8484a9b0acf90cf9
       - name: Install clang-format-19
@@ -24,12 +39,18 @@ jobs:
       - name: Check Formatting
         id: check_format
         continue-on-error: true
+        env:
+          CLANG_FORMAT_SCRIPT_DIR: ${{ case(github.repository != job.workflow_repository, env.WORKFLOW_PATH, env.REPO_PATH) }}
+        working-directory: ${{ env.REPO_PATH }}
         run: |
-          python3 scripts/clang_format.py --format-version 19 --commits HEAD^ HEAD
+          python3 "$CLANG_FORMAT_SCRIPT_DIR/scripts/clang_format.py" --format-version 19 --commits HEAD^ HEAD
       - name: Apply Formatting
         if: steps.check_format.outcome != 'success'
+        env:
+          CLANG_FORMAT_SCRIPT_DIR: ${{ case(github.repository != job.workflow_repository, env.WORKFLOW_PATH, env.REPO_PATH) }}
+        working-directory: ${{ env.REPO_PATH }}
         run: |
-          python3 scripts/clang_format.py --format-version 19 --modify --commits HEAD^ HEAD
+          python3 "$CLANG_FORMAT_SCRIPT_DIR/scripts/clang_format.py" --format-version 19 --modify --commits HEAD^ HEAD
       - name: Add Suggestions
         if: steps.check_format.outcome != 'success'
         uses: reviewdog/action-suggester@v1

--- a/.github/workflows/format_push.yml
+++ b/.github/workflows/format_push.yml
@@ -21,7 +21,7 @@ jobs:
           WORKFLOW_PATH: workflow/${{ job.workflow_repository }}
         run: |
           echo "WORKFLOW_PATH=$WORKFLOW_PATH" >> "$GITHUB_OUTPUT"
-          echo "CLANG_FORMAT_SCRIPT_DIR=${{ case(github.repository != job.workflow_repository, env.WORKFLOW_PATH, env.REPO_PATH) }}" >> $GITHUB_ENV
+          echo "CLANG_FORMAT_SCRIPT_DIR=$GITHUB_WORKSPACE/${{ case(github.repository != job.workflow_repository, env.WORKFLOW_PATH, env.REPO_PATH) }}" >> $GITHUB_ENV
       - uses: actions/checkout@v7
         with:
           path: ${{ env.REPO_PATH }}

--- a/.github/workflows/format_push.yml
+++ b/.github/workflows/format_push.yml
@@ -25,7 +25,8 @@ jobs:
       - uses: actions/checkout@v7
         with:
           path: ${{ env.REPO_PATH }}
-      - uses: actions/checkout@v7
+      - name: Checkout workflow script
+        uses: actions/checkout@v7
         if: ${{ github.repository != job.workflow_repository }}
         with:
           repository: ${{ job.workflow_repository }}

--- a/.github/workflows/format_push.yml
+++ b/.github/workflows/format_push.yml
@@ -5,13 +5,29 @@ on:
     branches:
       - develop
       - master
+  workflow_call:
 
 jobs:
   clang_format:
     runs-on: ubuntu-24.04
 
+    env:
+      REPO_PATH: repo/${{ github.repository }}
+      WORKFLOW_PATH: workflow/${{ job.workflow_repository }}
+
     steps:
       - uses: actions/checkout@v7
+        with:
+          path: ${{ env.REPO_PATH }}
+      - uses: actions/checkout@v7
+        if: ${{ github.repository != job.workflow_repository }}
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          path: ${{ env.WORKFLOW_PATH }}
+          sparse-checkout: |
+            scripts/clang_format.py
+          sparse-checkout-cone-mode: false
       - name: Add Problem Matcher
         uses: ammaraskar/gcc-problem-matcher@cb2e3f949c41b7818628f35f8484a9b0acf90cf9
       - name: Install clang-format-19
@@ -20,5 +36,8 @@ jobs:
           sudo apt-get install clang-format-19
           clang-format-19 --version
       - name: Check Formatting
+        env:
+          CLANG_FORMAT_SCRIPT_DIR: ${{ case(github.repository != job.workflow_repository, env.WORKFLOW_PATH, env.REPO_PATH) }}
+        working-directory: ${{ env.REPO_PATH }}
         run: |
-          python3 scripts/clang_format.py --format-version 19
+          python3 "$CLANG_FORMAT_SCRIPT_DIR/scripts/clang_format.py" --format-version 19

--- a/.github/workflows/format_push.yml
+++ b/.github/workflows/format_push.yml
@@ -13,9 +13,15 @@ jobs:
 
     env:
       REPO_PATH: repo/${{ github.repository }}
-      WORKFLOW_PATH: workflow/${{ job.workflow_repository }}
 
     steps:
+      - name: Setup env vars
+        id: setup_env_vars
+        env:
+          WORKFLOW_PATH: workflow/${{ job.workflow_repository }}
+        run: |
+          echo "WORKFLOW_PATH=$WORKFLOW_PATH" >> "$GITHUB_OUTPUT"
+          echo "CLANG_FORMAT_SCRIPT_DIR=${{ case(github.repository != job.workflow_repository, env.WORKFLOW_PATH, env.REPO_PATH) }}" >> $GITHUB_ENV
       - uses: actions/checkout@v7
         with:
           path: ${{ env.REPO_PATH }}
@@ -24,7 +30,7 @@ jobs:
         with:
           repository: ${{ job.workflow_repository }}
           ref: ${{ job.workflow_sha }}
-          path: ${{ env.WORKFLOW_PATH }}
+          path: ${{ steps.setup_env_vars.outputs.WORKFLOW_PATH }}
           sparse-checkout: |
             scripts/clang_format.py
           sparse-checkout-cone-mode: false
@@ -36,8 +42,6 @@ jobs:
           sudo apt-get install clang-format-19
           clang-format-19 --version
       - name: Check Formatting
-        env:
-          CLANG_FORMAT_SCRIPT_DIR: ${{ case(github.repository != job.workflow_repository, env.WORKFLOW_PATH, env.REPO_PATH) }}
         working-directory: ${{ env.REPO_PATH }}
         run: |
           python3 "$CLANG_FORMAT_SCRIPT_DIR/scripts/clang_format.py" --format-version 19


### PR DESCRIPTION
This change allows the format workflows to be used outside of this repo to avoid duplicating them in multiple of our repos.
See https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows